### PR TITLE
Fix generate script and ignore Python bytecode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.pyc
+__pycache__/
+

--- a/generate.sh
+++ b/generate.sh
@@ -6,8 +6,9 @@ INPUT_DIR="$SCRIPT_DIR/input"
 OUTPUT_DIR="$SCRIPT_DIR/output"
 
 mkdir -p "$OUTPUT_DIR"
+cd "$SCRIPT_DIR"
 
 shopt -s nullglob
 for json in "$INPUT_DIR"/*.json; do
-    python -m scenegen.cli --in "$json" --out-dir "$OUTPUT_DIR"
+    python3 -m scenegen.cli --in "$json" --out-dir "$OUTPUT_DIR"
 done


### PR DESCRIPTION
## Summary
- ensure generate.sh runs from repo directory and uses Python 3
- ignore Python bytecode files

## Testing
- `./generate.sh`


------
https://chatgpt.com/codex/tasks/task_e_6898a1ba2e0c833397e37180f9292636