### PR TITLE
Add session logging for CLI and generate script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 *.pyc
 __pycache__/
 
+# Session logs
+logs/*
+!logs/.gitkeep
+

--- a/generate.sh
+++ b/generate.sh
@@ -4,11 +4,17 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 INPUT_DIR="$SCRIPT_DIR/input"
 OUTPUT_DIR="$SCRIPT_DIR/output"
+LOG_DIR="$SCRIPT_DIR/logs"
 
-mkdir -p "$OUTPUT_DIR"
+mkdir -p "$OUTPUT_DIR" "$LOG_DIR"
+
+LOG_FILE="$LOG_DIR/bash_$(date '+%Y%m%d_%H%M%S').log"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
 cd "$SCRIPT_DIR"
 
 shopt -s nullglob
 for json in "$INPUT_DIR"/*.json; do
+    echo "Processing $json"
     python3 -m scenegen.cli --in "$json" --out-dir "$OUTPUT_DIR"
 done


### PR DESCRIPTION
## Summary
- add timestamped session logs for scenegen CLI
- capture generate.sh output in per-run log files
- ignore log artifacts in git

## Testing
- `bash generate.sh`
- `python3 -m scenegen.cli --in examples/scenes.json --out-dir output`


------
https://chatgpt.com/codex/tasks/task_e_6898a60e7c408333a3669f500dde8a49