### PR TITLE
Add Windows batch script for scene generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,13 @@ python -m scenegen.cli --in examples/scenes.json --out-dir /path/to/your/renpy/g
 
 ## Пакетная генерация
 
-В репозитории есть скрипт `generate.sh`, который обрабатывает все `.json` из
-директории `input` и кладёт результат в `output`:
+В репозитории есть скрипты `generate.sh` (Linux/macOS) и `generate.bat`
+(Windows), которые обрабатывают все `.json` из директории `input` и кладут
+результат в `output`:
 
 ```bash
 cp examples/scenes.json input/
-./generate.sh
+./generate.sh       # или generate.bat на Windows
 ```
 
 ## Что генерируется

--- a/generate.bat
+++ b/generate.bat
@@ -1,0 +1,26 @@
+@echo off
+setlocal
+
+set "SCRIPT_DIR=%~dp0"
+set "INPUT_DIR=%SCRIPT_DIR%input"
+set "OUTPUT_DIR=%SCRIPT_DIR%output"
+set "LOG_DIR=%SCRIPT_DIR%logs"
+
+if not exist "%OUTPUT_DIR%" mkdir "%OUTPUT_DIR%"
+if not exist "%LOG_DIR%" mkdir "%LOG_DIR%"
+
+for /f %%i in ('powershell -NoProfile -Command "Get-Date -Format yyyyMMdd_HHmmss"') do set "LOG_FILE=%LOG_DIR%\cmd_%%i.log"
+
+pushd "%SCRIPT_DIR%"
+
+if exist "%INPUT_DIR%\*.json" (
+    for %%F in ("%INPUT_DIR%\*.json") do (
+        powershell -NoProfile -Command "Write-Output ('Processing %%F') | Tee-Object -FilePath '%LOG_FILE%' -Append"
+        powershell -NoProfile -Command "python -m scenegen.cli --in '%%F' --out-dir '%OUTPUT_DIR%' 2>&1 | Tee-Object -FilePath '%LOG_FILE%' -Append"
+    )
+) else (
+    echo No JSON files found in %INPUT_DIR%
+)
+
+popd
+endlocal


### PR DESCRIPTION
## Summary
- add `generate.bat` to process JSON files on Windows with logging
- document Windows usage in README

## Testing
- `bash generate.sh` (no JSON files)


------
https://chatgpt.com/codex/tasks/task_e_6898a835cc0483339816b1625143a1e2