### PR TITLE
Restructure project with src layout, scripts, and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Example
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
 # make_renpy_script_from_json
+
+A small utility to convert JSON-described dialogues into a Ren'Py script.
+
+## Project structure
+
+```
+README.md
+LICENSE
+pyproject.toml
+scripts/
+    run.py
+src/
+    make_renpy_script/
+        __init__.py
+        converter.py
+tests/
+    test_converter.py
+```
+
+## Usage
+
+Install the package in editable mode and run the converter:
+
+```bash
+pip install -e .
+python scripts/run.py path/to/dialogue.json -o output.rpy
+```
+
+Run the test suite with:
+
+```bash
+pytest
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "make-renpy-script"
+version = "0.1.0"
+description = "Convert JSON dialogue descriptions to Ren'Py scripts"
+readme = "README.md"
+requires-python = ">=3.10"
+authors = [{name = "Example"}]

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""Command line interface to convert JSON dialogue to Ren'Py script."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from make_renpy_script import convert_file
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("json_file", type=Path, help="Path to the JSON file to convert")
+    parser.add_argument("--output", "-o", type=Path, help="Optional output file path")
+    args = parser.parse_args()
+
+    convert_file(args.json_file, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/make_renpy_script/__init__.py
+++ b/src/make_renpy_script/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities to generate Ren'Py scripts from JSON data."""
+
+from .converter import json_to_renpy
+
+__all__ = ["json_to_renpy"]

--- a/src/make_renpy_script/converter.py
+++ b/src/make_renpy_script/converter.py
@@ -1,0 +1,50 @@
+"""Convert structured JSON dialogue to a Ren'Py script."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Mapping, Any
+import json
+
+
+def json_to_renpy(data: Mapping[str, Any]) -> str:
+    """Convert a mapping describing dialogue into Ren'Py script text.
+
+    The input mapping is expected to have a ``dialogues`` key with an
+    iterable of dictionaries containing ``speaker`` and ``text`` keys.
+    """
+    lines: Iterable[str] = []
+    dialogues = data.get("dialogues", [])
+    for entry in dialogues:
+        speaker = entry.get("speaker", "")
+        text = entry.get("text", "")
+        if speaker:
+            lines.append(f"{speaker} \"{text}\"")
+        else:
+            lines.append(text)
+    return "\n".join(lines) + ("\n" if lines else "")
+
+
+def load_json(path: Path) -> Mapping[str, Any]:
+    """Load JSON content from a file."""
+    with path.open("r", encoding="utf8") as fh:
+        return json.load(fh)
+
+
+def convert_file(in_path: Path, out_path: Path | None = None) -> Path:
+    """Convert a JSON file to a Ren'Py script file.
+
+    Parameters
+    ----------
+    in_path:
+        Path to the input JSON file.
+    out_path:
+        Optional path for the output .rpy file. If not provided it will
+        be placed next to ``in_path`` with the same stem.
+    """
+    data = load_json(in_path)
+    script_text = json_to_renpy(data)
+    if out_path is None:
+        out_path = in_path.with_suffix(".rpy")
+    out_path.write_text(script_text, encoding="utf8")
+    return out_path

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,0 +1,18 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from make_renpy_script import json_to_renpy
+
+
+def test_json_to_renpy_simple():
+    data = {
+        "dialogues": [
+            {"speaker": "e", "text": "Hello"},
+            {"speaker": "l", "text": "Hi"},
+            {"text": "Scene change"},
+        ]
+    }
+    expected = "e \"Hello\"\nl \"Hi\"\nScene change\n"
+    assert json_to_renpy(data) == expected


### PR DESCRIPTION
## Summary
- Move converter logic into `src/make_renpy_script` package
- Add CLI utility under `scripts/run.py`
- Introduce basic unit test and adjust project docs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898b3761a208333b5314667df42802c