### PR TITLE
Refactor CLI entry point and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ scripts/
 src/
     make_renpy_script/
         __init__.py
+        __main__.py
         converter.py
 tests/
     test_converter.py
@@ -25,7 +26,7 @@ Install the package in editable mode and run the converter:
 
 ```bash
 pip install -e .
-python scripts/run.py path/to/dialogue.json -o output.rpy
+python -m make_renpy_script path/to/dialogue.json -o output.rpy
 ```
 
 Run the test suite with:

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -3,19 +3,7 @@
 
 from __future__ import annotations
 
-import argparse
-from pathlib import Path
-
-from make_renpy_script import convert_file
-
-
-def main() -> None:
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("json_file", type=Path, help="Path to the JSON file to convert")
-    parser.add_argument("--output", "-o", type=Path, help="Optional output file path")
-    args = parser.parse_args()
-
-    convert_file(args.json_file, args.output)
+from make_renpy_script.__main__ import main
 
 
 if __name__ == "__main__":

--- a/src/make_renpy_script/__init__.py
+++ b/src/make_renpy_script/__init__.py
@@ -1,7 +1,7 @@
 
 """Utilities to generate Ren'Py scripts from JSON data."""
 
-from .converter import json_to_renpy
+from .converter import json_to_renpy, convert_file
 
-__all__ = ["json_to_renpy"]
+__all__ = ["json_to_renpy", "convert_file"]
 

--- a/src/make_renpy_script/__main__.py
+++ b/src/make_renpy_script/__main__.py
@@ -1,12 +1,19 @@
 from __future__ import annotations
 
+import argparse
 from pathlib import Path
 
+from .converter import convert_file
 
-def main() -> None:
-    """Entry point for the ``make_renpy_script`` package."""
-    cwd = Path.cwd()
-    print(f"make_renpy_script executed from {cwd}")
+
+def main(argv: list[str] | None = None) -> None:
+    """Command line interface for the ``make_renpy_script`` package."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("json_file", type=Path, help="Path to the JSON file to convert")
+    parser.add_argument("--output", "-o", type=Path, help="Optional output file path")
+    args = parser.parse_args(argv)
+
+    convert_file(args.json_file, args.output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add argument parsing CLI to `make_renpy_script.__main__`
- delegate script wrapper to package entry point
- expose `convert_file` and document new usage

## Testing
- `pytest`
- `PYTHONPATH=src python -m make_renpy_script /tmp/sample.json -o /tmp/sample.rpy`


------
https://chatgpt.com/codex/tasks/task_e_6898c3f57d248333b3a96f2c93b33a19