### PR TITLE
fix: correct hotspot button signature

### DIFF
--- a/changelog/unreleased/fix-hotspot-button-signature.md
+++ b/changelog/unreleased/fix-hotspot-button-signature.md
@@ -1,0 +1,1 @@
+fix: correct _hotspot_button function signature

--- a/scenegen/generator.py
+++ b/scenegen/generator.py
@@ -105,7 +105,13 @@ def _layer_to_code(layer: Dict[str, Any], refw: int, refh: int, relative: bool, 
         return f"if {vis_if}:\n    {body}"
     return body
 
-def _hotspot_button(rect: Tuple[int, int, int, int], tooltip: str | None, hover: dict | None, action_code: str, name: str) -> str:
+def _hotspot_button(
+    rect: Tuple[int, int, int, int],
+    tooltip: str | None,
+    hover: dict | None,
+    action_code: str,
+    name: str,
+) -> str:
     x, y, w, h = rect
     # simple semi-transparent overlay + outline
     hover_lines = []


### PR DESCRIPTION
## Summary
- ensure _hotspot_button helper uses proper type-annotated signature
- document change in unreleased changelog

## Testing
- `python -m py_compile scenegen/generator.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898cdf450008333b45cd9569fcd353b