### PR TITLE
Support transitions in go_scene actions

### DIFF
--- a/scenegen/generator.py
+++ b/scenegen/generator.py
@@ -146,8 +146,9 @@ def _action_to_code(act: Dict[str, Any]) -> str:
     t = act["type"]
     if t == "go_scene":
         scene_id = act["scene_id"]
-        _transition_code(act.get("transition"))
-        return f"[SetField(store,'_next_scene','{scene_id}'), Jump('scene__internal__go')]"
+        transition = _transition_code(act.get("transition"))
+        action = f"[SetField(store,'_next_scene','{scene_id}'), Jump('scene__internal__go')]"
+        return f"{action} {transition}".rstrip()
     if t == "jump_label":
         label = act["label"]
         return f"Jump('{label}')"

--- a/tests/test_scenegen.py
+++ b/tests/test_scenegen.py
@@ -1,0 +1,50 @@
+import sys
+from pathlib import Path
+
+# Ensure the root of the repository is on the import path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from scenegen.generator import generate_rpy
+
+
+def test_go_scene_transition_applied():
+    data = {
+        "project": {
+            "reference_resolution": {"width": 100, "height": 100},
+            "coords_mode": "relative",
+        },
+        "scenes": [
+            {
+                "id": "one",
+                "name": "Scene 1",
+                "layers": [
+                    {"id": "bg", "type": "image", "image": "bg/one.png", "zorder": 0}
+                ],
+                "hotspots": [
+                    {
+                        "id": "to_two",
+                        "shape": "rect",
+                        "rect": {"x": 0.0, "y": 0.0, "w": 0.5, "h": 0.5},
+                        "action": {
+                            "type": "go_scene",
+                            "scene_id": "two",
+                            "transition": {"type": "fade", "duration": 0.3},
+                        },
+                    }
+                ],
+            },
+            {
+                "id": "two",
+                "name": "Scene 2",
+                "layers": [
+                    {"id": "bg", "type": "image", "image": "bg/two.png", "zorder": 0}
+                ],
+                "hotspots": [],
+            },
+        ],
+    }
+
+    files = generate_rpy(data)
+    screen = files["_gen/scene_one.rpy"]
+    assert "action [SetField(store,'_next_scene','two'), Jump('scene__internal__go')] with Fade(0.3)" in screen
+


### PR DESCRIPTION
## Summary
- append transition clauses to generated `go_scene` actions
- add unit test verifying transitions are included

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898d0c53a4c8333b8321d6dab8a8f6b