### PR TITLE
Escape braces in internal scene redirect

### DIFF
--- a/scenegen/generator.py
+++ b/scenegen/generator.py
@@ -207,7 +207,7 @@ def generate_rpy(data: Dict[str, Any]) -> Dict[str, str]:
             return
         $ _sc = _next_scene
         $ _next_scene = None
-        jump expression f"show_{_sc}"
+        jump expression f"show_{{_sc}}"
     """
         )
     )


### PR DESCRIPTION
## Summary
- Prevent Python's formatting of `_sc` in generated `scene__internal__go` by escaping braces

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898d766d85c8333a983cb39669c9921