### PR TITLE
Refactor hotspot hover block generation

### DIFF
--- a/scenegen/generator.py
+++ b/scenegen/generator.py
@@ -130,6 +130,7 @@ def _hotspot_button(
             "unhovered SetField(store, 'scene_tooltip', None)"
         )
 
+    hover_block = _indent("\n".join(hover_lines), 16)
     return f"""
     button:
         xpos {x} ypos {y} xsize {w} ysize {h}
@@ -138,7 +139,7 @@ def _hotspot_button(
         action {action_code}
         hovered:
             fixed:
-{_indent("\n".join(hover_lines), 16)}
+{hover_block}
     """.rstrip()
 
 def _action_to_code(act: Dict[str, Any]) -> str:


### PR DESCRIPTION
## Summary
- precompute hotspot hover block to avoid backslashes in f-string

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898e0bbfa848333a22942a590f690c6