### PR TITLE
chore: remove unused warning option

### DIFF
--- a/changelog/unreleased/remove-fail-on-warning.md
+++ b/changelog/unreleased/remove-fail-on-warning.md
@@ -1,0 +1,1 @@
+chore: remove unused --fail-on-warning CLI option

--- a/scenegen/cli.py
+++ b/scenegen/cli.py
@@ -22,7 +22,6 @@ def main(argv=None):
     p = argparse.ArgumentParser(prog="scenegen", description="SceneGen: JSON -> Ren'Py scenes generator")
     p.add_argument("--in", dest="infile", required=True, help="Input scenes JSON")
     p.add_argument("--out-dir", dest="outdir", required=True, help="Output directory (Ren'Py /game)")
-    p.add_argument("--fail-on-warning", action="store_true", help="(reserved)")
     args = p.parse_args(argv)
 
     log_file = _setup_logging()


### PR DESCRIPTION
## Summary
- remove unused `--fail-on-warning` option from scenegen CLI
- document removal in changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6898e0ce173c8333b107f28c74c15501