### PR TITLE
Normalize transition type comparisons

### DIFF
--- a/scenegen/generator.py
+++ b/scenegen/generator.py
@@ -28,6 +28,7 @@ def _transition_code(t: Dict[str, Any] | None) -> str:
     if not t:
         return ""
     ttype = t.get("type", "dissolve")
+    ttype = ttype.lower()
     dur = t.get("duration", 0.2)
     # map a few common names
     mapping = {

--- a/tests/test_scenegen.py
+++ b/tests/test_scenegen.py
@@ -48,3 +48,48 @@ def test_go_scene_transition_applied():
     screen = files["_gen/scene_one.rpy"]
     assert "action [SetField(store,'_next_scene','two'), Jump('scene__internal__go')] with Fade(0.3)" in screen
 
+
+def test_go_scene_transition_mixed_case_type():
+    data = {
+        "project": {
+            "reference_resolution": {"width": 100, "height": 100},
+            "coords_mode": "relative",
+        },
+        "scenes": [
+            {
+                "id": "one",
+                "name": "Scene 1",
+                "layers": [
+                    {"id": "bg", "type": "image", "image": "bg/one.png", "zorder": 0}
+                ],
+                "hotspots": [
+                    {
+                        "id": "to_two",
+                        "shape": "rect",
+                        "rect": {"x": 0.0, "y": 0.0, "w": 0.5, "h": 0.5},
+                        "action": {
+                            "type": "go_scene",
+                            "scene_id": "two",
+                            "transition": {"type": "WiPeLeFt", "duration": 0.3},
+                        },
+                    }
+                ],
+            },
+            {
+                "id": "two",
+                "name": "Scene 2",
+                "layers": [
+                    {"id": "bg", "type": "image", "image": "bg/two.png", "zorder": 0}
+                ],
+                "hotspots": [],
+            },
+        ],
+    }
+
+    files = generate_rpy(data)
+    screen = files["_gen/scene_one.rpy"]
+    assert (
+        "action [SetField(store,'_next_scene','two'), Jump('scene__internal__go')] "
+        "with SlideTransition(push_side='left', duration=0.3)" in screen
+    )
+


### PR DESCRIPTION
## Summary
- lower-case transition types in `_transition_code` before evaluating mappings
- add tests ensuring mixed-case transition names resolve correctly

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898e3501f8083339f8c1a42bbd3ba47