### PR TITLE
Add logging capabilities to run script

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -2,7 +2,14 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOG_DIR="$SCRIPT_DIR/logs"
+LOG_FILE="$LOG_DIR/run.log"
 VENV_DIR="$SCRIPT_DIR/.venv"
+
+mkdir -p "$LOG_DIR"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+echo "$(date) – Starting scenegen"
 
 if [ ! -d "$VENV_DIR" ]; then
     echo "Virtual environment not found. Run ./setup.sh first." >&2


### PR DESCRIPTION
## Summary
- capture run script output in logs/run.log and timestamp start message

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898e6e40ff48333b5a634eb05f95dc3