### PR TITLE
chore: add logging to setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -3,12 +3,19 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 VENV_DIR="$SCRIPT_DIR/.venv"
+LOG_DIR="$SCRIPT_DIR/logs"
+LOG_FILE="$LOG_DIR/setup.log"
+mkdir -p "$LOG_DIR"
+exec > >(tee -a "$LOG_FILE") 2>&1
 
+echo "$(date) – Creating virtual environment in $VENV_DIR"
 python3 -m venv "$VENV_DIR"
 source "$VENV_DIR/bin/activate"
+echo "$(date) – Upgrading pip"
 pip install --upgrade pip
 if [ -f "$SCRIPT_DIR/requirements.txt" ]; then
+    echo "$(date) – Installing packages from requirements.txt"
     pip install -r "$SCRIPT_DIR/requirements.txt"
 fi
 
-echo "Virtual environment created in $VENV_DIR"
+echo "$(date) – Virtual environment created in $VENV_DIR"


### PR DESCRIPTION
## Summary
- add log directory and file to setup script
- ensure setup output is logged and major steps timestamped

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898e6e9fbe88333af5365b18eb36746