### PR TITLE
Add Windows run and setup scripts

### DIFF
--- a/run.bat
+++ b/run.bat
@@ -1,0 +1,26 @@
+@echo off
+setlocal
+
+set "SCRIPT_DIR=%~dp0"
+set "LOG_DIR=%SCRIPT_DIR%logs"
+set "LOG_FILE=%LOG_DIR%\run.log"
+set "VENV_DIR=%SCRIPT_DIR%.venv"
+
+if not exist "%LOG_DIR%" mkdir "%LOG_DIR%"
+
+pushd "%SCRIPT_DIR%"
+
+powershell -NoProfile -Command "Write-Output (Get-Date -Format 'u' + ' – Starting scenegen') | Tee-Object -FilePath '%LOG_FILE%' -Append"
+
+if not exist "%VENV_DIR%\Scripts\activate.bat" (
+    echo Virtual environment not found. Run setup.bat first.
+    popd
+    exit /b 1
+)
+
+call "%VENV_DIR%\Scripts\activate.bat"
+
+powershell -NoProfile -Command "python -m scenegen.cli %* 2>&1 | Tee-Object -FilePath '%LOG_FILE%' -Append"
+
+popd
+endlocal

--- a/setup.bat
+++ b/setup.bat
@@ -1,0 +1,31 @@
+@echo off
+setlocal
+
+set "SCRIPT_DIR=%~dp0"
+set "VENV_DIR=%SCRIPT_DIR%.venv"
+set "LOG_DIR=%SCRIPT_DIR%logs"
+set "LOG_FILE=%LOG_DIR%\setup.log"
+
+if not exist "%LOG_DIR%" mkdir "%LOG_DIR%"
+
+pushd "%SCRIPT_DIR%"
+
+powershell -NoProfile -Command "Write-Output (Get-Date -Format 'u' + ' – Creating virtual environment in %VENV_DIR%') | Tee-Object -FilePath '%LOG_FILE%' -Append"
+
+powershell -NoProfile -Command "python -m venv '%VENV_DIR%' 2>&1 | Tee-Object -FilePath '%LOG_FILE%' -Append"
+
+call "%VENV_DIR%\Scripts\activate.bat"
+
+powershell -NoProfile -Command "Write-Output (Get-Date -Format 'u' + ' – Upgrading pip') | Tee-Object -FilePath '%LOG_FILE%' -Append"
+
+powershell -NoProfile -Command "pip install --upgrade pip 2>&1 | Tee-Object -FilePath '%LOG_FILE%' -Append"
+
+if exist "%SCRIPT_DIR%requirements.txt" (
+    powershell -NoProfile -Command "Write-Output (Get-Date -Format 'u' + ' – Installing packages from requirements.txt') | Tee-Object -FilePath '%LOG_FILE%' -Append"
+    powershell -NoProfile -Command "pip install -r '%SCRIPT_DIR%requirements.txt' 2>&1 | Tee-Object -FilePath '%LOG_FILE%' -Append"
+)
+
+powershell -NoProfile -Command "Write-Output (Get-Date -Format 'u' + ' – Virtual environment created in %VENV_DIR%') | Tee-Object -FilePath '%LOG_FILE%' -Append"
+
+popd
+endlocal


### PR DESCRIPTION
## Summary
- Provide `run.bat` to execute scenegen on Windows with logging and virtualenv handling
- Add `setup.bat` to create and configure a virtual environment on Windows

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898e90e5ea883338175ffb2719307ca