### PR TITLE
Add dialoggen test scaffolding using spec examples

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,81 @@
+import sys
+from pathlib import Path
+import pytest
+
+# Ensure repository root is on sys.path for importing dialoggen once available
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+@pytest.fixture
+def dialog_tree():
+    """Example dialog tree taken from the spec's examples."""
+    return {
+        "id": "day1_intro",
+        "title": "День 1 — вступление",
+        "entry_node": "n_start",
+        "locals": [{"name": "mood", "type": "str", "default": "neutral"}],
+        "using_characters": ["narrator", "e"],
+        "nodes": [
+            {
+                "id": "n_start",
+                "type": "say",
+                "character": "e",
+                "text": "Привет! Сегодня начнём.",
+                "next": "n_choice_1",
+            },
+            {
+                "id": "n_choice_1",
+                "type": "choice",
+                "prompt": "Как ответить?",
+                "choices": [
+                    {
+                        "id": "c_ask",
+                        "text": "Спросить про курс",
+                        "effects": ["interest='course'"],
+                        "next": "n_gate",
+                    },
+                    {
+                        "id": "c_silent",
+                        "text": "Промолчать",
+                        "next": "n_ret",
+                    },
+                ],
+            },
+            {
+                "id": "n_gate",
+                "type": "if",
+                "branches": [
+                    {"condition": "mood=='happy'", "next": "n_happy"},
+                    {"condition": "True", "next": "n_neutral"},
+                ],
+            },
+            {
+                "id": "n_happy",
+                "type": "say",
+                "character": "e",
+                "text": "Классное настроение!",
+                "next": "n_ret",
+            },
+            {
+                "id": "n_neutral",
+                "type": "say",
+                "character": "e",
+                "text": "Окей, продолжим.",
+                "next": "n_ret",
+            },
+            {"id": "n_ret", "type": "return"},
+        ],
+    }
+
+
+@pytest.fixture
+def dialog_project(dialog_tree):
+    """Top level project structure including the example dialog tree."""
+    return {
+        "version": "1.0",
+        "project": {
+            "language": "ru",
+            "default_character": "narrator",
+            "naming": {"label_prefix": "dlg_", "menu_prefix": "m_"},
+        },
+        "dialog_trees": [dialog_tree],
+    }

--- a/tests/test_dialoggen_cli.py
+++ b/tests/test_dialoggen_cli.py
@@ -1,0 +1,30 @@
+import json
+import subprocess
+import sys
+
+
+def test_cli_processes_single_file(tmp_path, dialog_project):
+    src = tmp_path / "dialogs.json"
+    src.write_text(json.dumps(dialog_project), encoding="utf8")
+    out_dir = tmp_path / "out"
+    result = subprocess.run(
+        [sys.executable, "-m", "dialoggen.cli", "--in", str(src), "--out-dir", str(out_dir)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert (out_dir / "dialogs_day1_intro.rpy").exists()
+
+
+def test_cli_processes_directory(tmp_path, dialog_project):
+    src_dir = tmp_path / "input"
+    src_dir.mkdir()
+    (src_dir / "tree.json").write_text(json.dumps(dialog_project), encoding="utf8")
+    out_dir = tmp_path / "out"
+    result = subprocess.run(
+        [sys.executable, "-m", "dialoggen.cli", "--in", str(src_dir), "--out-dir", str(out_dir)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert (out_dir / "dialogs_day1_intro.rpy").exists()

--- a/tests/test_dialoggen_generator.py
+++ b/tests/test_dialoggen_generator.py
@@ -1,0 +1,13 @@
+from dialoggen.generator import generate_rpy
+
+
+def test_generate_rpy_outputs_expected_labels(dialog_project):
+    files = generate_rpy(dialog_project)
+    assert "dialogs_day1_intro.rpy" in files
+    script = files["dialogs_day1_intro.rpy"]
+    assert "label dlg_day1_intro__start" in script
+    assert "label dlg_day1_intro__n_start" in script
+    assert 'e "Привет! Сегодня начнём."' in script
+    assert "menu" in script
+    assert "if mood=='happy'" in script
+    assert "return" in script

--- a/tests/test_dialoggen_validator.py
+++ b/tests/test_dialoggen_validator.py
@@ -1,0 +1,22 @@
+import json
+import pytest
+
+from dialoggen.validator import validate, ValidationError
+
+
+def test_validator_accepts_valid(dialog_project):
+    validate(dialog_project)
+
+
+def test_validator_detects_missing_entry(dialog_project):
+    invalid = json.loads(json.dumps(dialog_project))
+    invalid["dialog_trees"][0].pop("entry_node", None)
+    with pytest.raises(ValidationError):
+        validate(invalid)
+
+
+def test_validator_detects_unknown_link(dialog_project):
+    invalid = json.loads(json.dumps(dialog_project))
+    invalid["dialog_trees"][0]["nodes"][0]["next"] = "missing_node"
+    with pytest.raises(ValidationError):
+        validate(invalid)


### PR DESCRIPTION
## Summary
- add fixtures based on dialog JSON example from spec
- add validator tests for structural errors and invalid references
- add generator tests to verify emitted labels and branches
- add CLI tests covering single file and directory inputs

## Testing
- `pytest tests/test_dialoggen_validator.py tests/test_dialoggen_generator.py tests/test_dialoggen_cli.py` *(fails: ModuleNotFoundError: No module named 'dialoggen')*


------
https://chatgpt.com/codex/tasks/task_e_6898f1365fa08333aef12f2fc349a076