### PR TITLE
Add dialogue JSON examples

### DIFF
--- a/examples/dialog_basic.json
+++ b/examples/dialog_basic.json
@@ -1,0 +1,34 @@
+{
+  "version": "1.0",
+  "project": {
+    "language": "ru",
+    "default_character": "narrator",
+    "naming": { "label_prefix": "dlg_", "menu_prefix": "m_" }
+  },
+  "dialog_trees": [
+    {
+      "id": "day1_intro",
+      "title": "День 1 — вступление",
+      "entry_node": "n_start",
+      "locals": [
+        { "name": "mood", "type": "str", "default": "neutral" }
+      ],
+      "using_characters": ["narrator", "e", "m"],
+      "nodes": [
+        { "id": "n_start", "type": "say", "character": "e",
+          "text": "Привет! Сегодня начнём.", "next": "n_choice_1" },
+        {
+          "id": "n_choice_1", "type": "choice", "prompt": "Как ответить?",
+          "choices": [
+            { "id": "c_ask", "text": "Спросить про курс",
+              "effects": ["interest = 'course'"], "next": "n_after" },
+            { "id": "c_silent", "text": "Промолчать", "next": "n_after" }
+          ]
+        },
+        { "id": "n_after", "type": "say", "character": "m",
+          "text": "Что ж, продолжим.", "next": "n_end" },
+        { "id": "n_end", "type": "return" }
+      ]
+    }
+  ]
+}

--- a/examples/dialog_branching.json
+++ b/examples/dialog_branching.json
@@ -1,0 +1,35 @@
+{
+  "version": "1.0",
+  "project": {
+    "language": "ru",
+    "default_character": "narrator",
+    "naming": { "label_prefix": "dlg_", "menu_prefix": "m_" }
+  },
+  "dialog_trees": [
+    {
+      "id": "branching_demo",
+      "title": "Демонстрация ветвления",
+      "entry_node": "n_start",
+      "nodes": [
+        { "id": "n_start", "type": "script",
+          "code": ["points += 1"], "next": "n_gate" },
+        { "id": "n_gate", "type": "if",
+          "branches": [
+            { "condition": "points > 3", "next": "n_bonus" },
+            { "condition": "True",       "next": "n_regular" }
+          ]
+        },
+        { "id": "n_bonus", "type": "say", "character": "e",
+          "text": "Ты набрал много очков!", "voice": "voice/bonus.ogg",
+          "text_tags": ["b"], "next": "n_screen" },
+        { "id": "n_regular", "type": "say", "character": "e",
+          "text": "Продолжай стараться.", "next": "n_screen" },
+        { "id": "n_screen", "type": "screen",
+          "screen": "inventory", "params": { "filter": "quest" },
+          "next": "n_jump" },
+        { "id": "n_jump", "type": "jump", "label": "after_dialog" },
+        { "id": "n_ret", "type": "return" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add basic dialogue sample demonstrating choice handling
- include branching dialogue example with conditional logic and screen/jump nodes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898f18855048333bc9930fde251aacf