### PR TITLE
feat: auto-detect JSON module in CLI

### DIFF
--- a/src/make_renpy_script/cli.py
+++ b/src/make_renpy_script/cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
+from typing import Any, Mapping, Literal
 
 from scenegen.generator import generate_rpy
 from scenegen.validator import validate
@@ -10,19 +11,27 @@ from scenegen.validator import validate
 from .converter import convert_file
 
 
-def _convert_dialogue(src: Path, outdir: Path) -> None:
-    """Convert dialogue JSON files into Ren'Py scripts."""
-    if src.is_dir():
-        for json_file in src.glob("*.json"):
-            convert_file(json_file, outdir / f"{json_file.stem}.rpy")
+def detect_module(data: Mapping[str, Any]) -> Literal["dialogue", "scenes"]:
+    """Determine which processing pipeline to use based on top-level keys."""
+    keys = set(data)
+    if "dialogues" in keys:
+        return "dialogue"
+    if "scenes" in keys or "project" in keys:
+        return "scenes"
+    raise ValueError("JSON must contain 'dialogues' or 'scenes'/'project' keys")
+
+
+def _process_json(path: Path, outdir: Path) -> None:
+    """Process a single JSON file into Ren'Py script(s)."""
+    data = json.loads(path.read_text(encoding="utf-8"))
+    try:
+        module = detect_module(data)
+    except ValueError as exc:  # pragma: no cover - error path
+        raise ValueError(f"{path}: {exc}") from exc
+
+    if module == "dialogue":
+        convert_file(path, outdir / f"{path.stem}.rpy")
     else:
-        convert_file(src, outdir / f"{src.stem}.rpy")
-
-
-def _generate_scenes(src: Path, outdir: Path) -> None:
-    """Generate Ren'Py scene files from scene JSON."""
-    def _process(json_path: Path) -> None:
-        data = json.loads(json_path.read_text(encoding="utf-8"))
         validate(data)
         files = generate_rpy(data)
         for rel, content in files.items():
@@ -30,34 +39,23 @@ def _generate_scenes(src: Path, outdir: Path) -> None:
             target.parent.mkdir(parents=True, exist_ok=True)
             target.write_text(content, encoding="utf-8")
 
-    if src.is_dir():
-        for json_file in src.glob("*.json"):
-            _process(json_file)
-    else:
-        _process(src)
-
 
 def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="Utilities to generate Ren'Py content from JSON")
-    sub = parser.add_subparsers(dest="command", required=True)
-
-    dlg = sub.add_parser("dialogue", help="Convert dialogue JSON to .rpy files")
-    dlg.add_argument("path", nargs="?", type=Path, default=Path("input"), help="JSON file or directory")
-    dlg.add_argument("-o", "--output", type=Path, default=Path("output"), help="Output directory")
-
-    scn = sub.add_parser("scenes", help="Generate scenes from JSON")
-    scn.add_argument("path", nargs="?", type=Path, default=Path("input"), help="JSON file or directory")
-    scn.add_argument("-o", "--output", type=Path, default=Path("output"), help="Output directory")
+    parser.add_argument("path", nargs="?", type=Path, default=Path("input"), help="JSON file or directory")
+    parser.add_argument("-o", "--output", type=Path, default=Path("output"), help="Output directory")
 
     args = parser.parse_args(argv)
 
     outdir: Path = args.output
     outdir.mkdir(parents=True, exist_ok=True)
 
-    if args.command == "dialogue":
-        _convert_dialogue(args.path, outdir)
+    src = args.path
+    if src.is_dir():
+        for json_file in src.glob("*.json"):
+            _process_json(json_file, outdir)
     else:
-        _generate_scenes(args.path, outdir)
+        _process_json(src, outdir)
 
 
 if __name__ == "__main__":

--- a/tests/test_cli_detection.py
+++ b/tests/test_cli_detection.py
@@ -1,0 +1,18 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+sys.path.append(str(ROOT / "src"))
+
+from make_renpy_script.cli import detect_module
+
+
+def test_detect_module_dialogue():
+    data = {"dialogues": []}
+    assert detect_module(data) == "dialogue"
+
+
+def test_detect_module_scenes():
+    data = {"project": {}, "scenes": []}
+    assert detect_module(data) == "scenes"


### PR DESCRIPTION
## Summary
- add `detect_module` helper to route JSON to dialogue or scene generators
- replace subcommands with unified file processor and automatic detection
- test module detection for dialogue and scene inputs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6898fa839d608333a9c8a303af3eb385