### PR TITLE
Use transition objects for go_scene actions

### DIFF
--- a/docs/renpy_scene_editor_spec.md
+++ b/docs/renpy_scene_editor_spec.md
@@ -126,7 +126,7 @@ screen scene_hall():
         xpos 192 ypos 162 xsize 288 ysize 216
         focus_mask True
         hovered SetField(store, 'scene_tooltip', _(\"В класс\")) unhovered SetField(store, 'scene_tooltip', None)
-        action [SetField(store,'_next_scene','classroom'), Jump('scene__internal__go')]
+        action [Function(renpy.transition, SlideTransition(push_side='left', duration=0.25)), SetField(store,'_next_scene','classroom'), Jump('scene__internal__go')]
         hovered:
             fixed:
                 add Solid('#FFFFFF', xysize (288,26)) alpha 0.12

--- a/tests/test_scenegen.py
+++ b/tests/test_scenegen.py
@@ -46,5 +46,8 @@ def test_go_scene_transition_applied():
 
     files = generate_rpy(data)
     screen = files["_gen/scene_one.rpy"]
-    assert "action [SetField(store,'_next_scene','two'), Jump('scene__internal__go')] with Fade(0.3)" in screen
+    assert (
+        "action [Function(renpy.transition, Fade(0.3)), SetField(store,'_next_scene','two'), Jump('scene__internal__go')]"
+        in screen
+    )
 


### PR DESCRIPTION
## Summary
- Allow `_transition_code` to return transition objects when needed for actions
- Build `go_scene` actions with `Function(renpy.transition, ...)` before scene jump
- Document and test new action syntax

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898fa8d50808333b090e85defe8cfa9