### PR TITLE
Use Ren'Py scene expression for backgrounds

### DIFF
--- a/docs/renpy_scene_editor_spec.md
+++ b/docs/renpy_scene_editor_spec.md
@@ -132,7 +132,7 @@ screen scene_hall():
                 add Solid('#FFFFFF', xysize (288,26)) alpha 0.12
 
 label show_hall:
-    scene bg/hall_day.png with Fade(0.3)
+    scene expression "bg/hall_day.png" with Fade(0.3)
     show screen scene_hall
     show screen scene_tooltip_overlay
     $ renpy.pause(0)

--- a/scenegen/generator.py
+++ b/scenegen/generator.py
@@ -259,7 +259,7 @@ def generate_rpy(data: Dict[str, Any]) -> Dict[str, str]:
                 bg_image = L["image"]
                 break
         if bg_image:
-            lbl.append(f"    scene {bg_image} {enter_t}".rstrip())
+            lbl.append(f'    scene expression "{bg_image}" {enter_t}'.rstrip())
         else:
             lbl.append("    # scene has no base image layer")
         lbl.append(f"    show screen scene_{sid}")

--- a/tests/test_scenegen.py
+++ b/tests/test_scenegen.py
@@ -47,4 +47,6 @@ def test_go_scene_transition_applied():
     files = generate_rpy(data)
     screen = files["_gen/scene_one.rpy"]
     assert "action [SetField(store,'_next_scene','two'), Jump('scene__internal__go')] with Fade(0.3)" in screen
+    assert 'scene expression "bg/one.png"' in screen
+
 


### PR DESCRIPTION
## Summary
- Switch scene generation to use `scene expression` and quote background paths
- Test for the new `scene expression` syntax in generated scenes
- Document updated `scene expression` usage in spec

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898fa8fea108333ac3e6819388f83b0