### PR TITLE
Refactor generator entry points and CLI

### DIFF
--- a/dialoggen/__init__.py
+++ b/dialoggen/__init__.py
@@ -1,0 +1,9 @@
+from pkgutil import extend_path
+import pathlib
+import sys
+
+_src = pathlib.Path(__file__).resolve().parent.parent / "src"
+if str(_src) not in sys.path:
+    sys.path.insert(0, str(_src))
+
+__path__ = extend_path(__path__, __name__)

--- a/src/make_renpy_script/__init__.py
+++ b/src/make_renpy_script/__init__.py
@@ -1,7 +1,12 @@
-
 """Utilities to generate Ren'Py scripts from JSON data."""
 
 from .converter import json_to_renpy, convert_file
+from .generators import generate_dialogue, generate_scenes
 
-__all__ = ["json_to_renpy", "convert_file"]
+__all__ = [
+    "json_to_renpy",
+    "convert_file",
+    "generate_dialogue",
+    "generate_scenes",
+]
 

--- a/src/make_renpy_script/generators.py
+++ b/src/make_renpy_script/generators.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+from dialoggen.generator import generate_rpy as _generate_dialogue_rpy
+from dialoggen.validator import validate as _validate_dialogue
+from scenegen.generator import generate_rpy as _generate_scene_rpy
+from scenegen.validator import validate as _validate_scene
+
+
+def generate_dialogue(data: Dict[str, Any]) -> Dict[Path, str]:
+    """Generate Ren'Py dialogue files from validated ``data``."""
+    _validate_dialogue(data)
+    return _generate_dialogue_rpy(data)
+
+
+def generate_scenes(data: Dict[str, Any]) -> Dict[Path, str]:
+    """Generate Ren'Py scene files from validated ``data``."""
+    _validate_scene(data)
+    files = _generate_scene_rpy(data)
+    return {Path(name): content for name, content in files.items()}


### PR DESCRIPTION
## Summary
- add `generators` module with separate dialog and scene generators
- refactor CLI to use encapsulated generators and support directory processing
- update dialog generator for optional localization and filename aliases

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898faea983c8333b6461ddce70d54e1