### PR TITLE
Handle invalid JSON in dialoggen CLI

### DIFF
--- a/src/dialoggen/cli.py
+++ b/src/dialoggen/cli.py
@@ -28,7 +28,11 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     def _process(path: Path) -> int:
-        data = json.loads(path.read_text(encoding="utf-8"))
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            print(f"JSON decode error: {exc}", file=sys.stderr)
+            return 4
         try:
             validate(data)
         except ValidationError as exc:

--- a/tests/test_dialoggen_cli.py
+++ b/tests/test_dialoggen_cli.py
@@ -28,3 +28,15 @@ def test_cli_processes_directory(tmp_path, dialog_project):
     )
     assert result.returncode == 0
     assert (out_dir / "dialogs_day1_intro.rpy").exists()
+
+
+def test_cli_invalid_json_returns_error(tmp_path):
+    src = tmp_path / "bad.json"
+    src.write_text("{", encoding="utf8")
+    out_dir = tmp_path / "out"
+    result = subprocess.run(
+        [sys.executable, "-m", "dialoggen.cli", "--in", str(src), "--out-dir", str(out_dir)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0


### PR DESCRIPTION
## Summary
- handle invalid JSON in dialoggen CLI by returning an error code and logging to stderr
- cover invalid JSON handling with a new CLI test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898ff5ef12c8333b4615b44230b35d3