### PR TITLE
Escape dialogue text with json.dumps

### DIFF
--- a/src/make_renpy_script/converter.py
+++ b/src/make_renpy_script/converter.py
@@ -19,7 +19,7 @@ def json_to_renpy(data: Mapping[str, Any]) -> str:
         speaker = entry.get("speaker", "")
         text = entry.get("text", "")
         if speaker:
-            lines.append(f'{speaker} "{text}"')
+            lines.append(f"{speaker} {json.dumps(text)}")
         else:
             lines.append(text)
     return "\n".join(lines) + ("\n" if lines else "")

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -16,3 +16,13 @@ def test_json_to_renpy_simple():
     }
     expected = "e \"Hello\"\nl \"Hi\"\nScene change\n"
     assert json_to_renpy(data) == expected
+
+
+def test_json_to_renpy_with_quotes():
+    data = {
+        "dialogues": [
+            {"speaker": "e", "text": "She said \"Hi\""},
+        ]
+    }
+    expected = 'e "She said \\"Hi\\""\n'
+    assert json_to_renpy(data) == expected


### PR DESCRIPTION
## Summary
- escape quoted dialogue text in Ren'Py converter using `json.dumps`
- test handling of dialogue lines containing quotes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898ff60f808833388d234a3411306c9